### PR TITLE
Decode jwt token

### DIFF
--- a/snowflake/ingest/utils/tokentools.py
+++ b/snowflake/ingest/utils/tokentools.py
@@ -81,4 +81,4 @@ class SecurityManager(object):
             self.token = jwt.encode(payload, self.private_key, algorithm=SecurityManager.ALGORITHM)
             logger.info("New Token is %s", self.token)
 
-        return self.token
+        return self.token.decode('utf-8')


### PR DESCRIPTION
self.token is in bytes format. If not decoded, token will be like b'...' (prepended b means bytes in Python), which will cause authentication failure in the server side.