### PR TITLE
SNOW-88101: Python 3.5.0 and 3.5.1 support for typing module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ if version_info[0] < 3 or version_info[1] < 4:
 elif version_info[1] == 4:
     DEPENDS.append("typing")
 
+# Python 3.5.0 and 3.5.1 have incompatible typing modules. Use typing_extensions instead.
+elif version_info[1] == 5 and version_info[2] < 2:
+    DEPENDS.append("typing_extensions")
+
 here = os.path.abspath(os.path.dirname(__file__))
 
 def test_suite():

--- a/snowflake/ingest/simple_ingest_manager.py
+++ b/snowflake/ingest/simple_ingest_manager.py
@@ -27,12 +27,12 @@ import platform
 from logging import getLogger
 logger = getLogger(__name__)
 
+from typing import Dict, Any
 try:
-    from typing import Text, Dict, Any
+    from typing import Text
 except ImportError:
     logger.debug('# Python 3.5.0 and 3.5.1 have incompatible typing modules.', exc_info=True)
     from typing_extensions import Text
-    from typing import Dict, Any
 
 # We just need a simple named tuple to represent remote files
 StagedFile = namedtuple("StagedFile", ["path", "size"])

--- a/snowflake/ingest/simple_ingest_manager.py
+++ b/snowflake/ingest/simple_ingest_manager.py
@@ -18,9 +18,6 @@ from .version import __version__
 # We use a named tuple to represent remote files
 from collections import namedtuple
 
-# Typing information
-from typing import Text, Dict, Any
-
 # UUID for typing formation
 from uuid import UUID
 
@@ -29,6 +26,13 @@ import platform
 
 from logging import getLogger
 logger = getLogger(__name__)
+
+try:
+    from typing import Text, Dict, Any
+except ImportError:
+    logger.debug('# Python 3.5.0 and 3.5.1 have incompatible typing modules.', exc_info=True)
+    from typing_extensions import Text
+    from typing import Dict, Any
 
 # We just need a simple named tuple to represent remote files
 StagedFile = namedtuple("StagedFile", ["path", "size"])

--- a/snowflake/ingest/utils/network.py
+++ b/snowflake/ingest/utils/network.py
@@ -12,12 +12,12 @@ from ..error import IngestResponseError
 from logging import getLogger
 logger = getLogger(__name__)
 
+from typing import Dict, Any
 try:
-    from typing import Text, Dict, Any
+    from typing import Text
 except ImportError:
     logger.debug('# Python 3.5.0 and 3.5.1 have incompatible typing modules.', exc_info=True)
     from typing_extensions import Text
-    from typing import Dict, Any
 
 # default timeout in seconds for a rest request
 DEFAULT_REQUEST_TIMEOUT = 1 * 60

--- a/snowflake/ingest/utils/network.py
+++ b/snowflake/ingest/utils/network.py
@@ -1,5 +1,3 @@
-from typing import Text, Dict, Any
-
 # import to use ocsp module in python connector
 # this import will inject ocsp check method into
 # botocore.vendored.requests library
@@ -13,6 +11,13 @@ from ..error import IngestResponseError
 
 from logging import getLogger
 logger = getLogger(__name__)
+
+try:
+    from typing import Text, Dict, Any
+except ImportError:
+    logger.debug('# Python 3.5.0 and 3.5.1 have incompatible typing modules.', exc_info=True)
+    from typing_extensions import Text
+    from typing import Dict, Any
 
 # default timeout in seconds for a rest request
 DEFAULT_REQUEST_TIMEOUT = 1 * 60

--- a/snowflake/ingest/utils/tokentools.py
+++ b/snowflake/ingest/utils/tokentools.py
@@ -5,7 +5,6 @@ tokentools.py - provides services for automatically creating and renewing
 JWT tokens for authenticating to Snowflake
 """
 
-from typing import Text
 from datetime import timedelta, datetime
 from logging import getLogger
 from cryptography.exceptions import UnsupportedAlgorithm
@@ -21,6 +20,12 @@ import hashlib
 import jwt
 
 logger = getLogger(__name__)
+
+try:
+    from typing import Text
+except ImportError:
+    logger.debug('# Python 3.5.0 and 3.5.1 have incompatible typing modules.', exc_info=True)
+    from typing_extensions import Text
 
 ISSUER = "iss"
 EXPIRE_TIME = "exp"

--- a/snowflake/ingest/utils/uris.py
+++ b/snowflake/ingest/utils/uris.py
@@ -7,11 +7,16 @@ requests and history requests
 
 from uuid import uuid4, UUID
 from furl import furl
-from typing import Text
 from logging import getLogger
 
 # Create a logger for this module
 logger = getLogger(__name__)
+
+try:
+    from typing import Text
+except ImportError:
+    logger.debug('# Python 3.5.0 and 3.5.1 have incompatible typing modules.', exc_info=True)
+    from typing_extensions import Text
 
 # URI Construction constants we use for making a target URL
 DEFAULT_HOST_FMT = "{}.snowflakecomputing.com"  # by default we target the Snowflake US instance


### PR DESCRIPTION
Some of the typing modules (ex. Text) are not supported in Python 3.5.0 and 3.5.1. This change adds TRY block around such imports and if an ImportError exception is thrown, uses the typing_extension module instead.

I have tested this with Python 3.5.1 by running tests/test_*.py and confirmed it works as expected.