### PR TITLE
Replacing botocore requests library with standalone requests library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ import os
 # We need to know the version to backfill some dependencies
 from sys import version_info, exit
 # Define our list of installation dependencies
-DEPENDS = ["pyjwt", "snowflake-connector-python", "furl", "cryptography"]
+DEPENDS = ["pyjwt", "snowflake-connector-python", "furl", "cryptography",
+           'requests']
 
 # If we're at version less than 3.4 - fail
 if version_info[0] < 3 or version_info[1] < 4:

--- a/snowflake/ingest/error.py
+++ b/snowflake/ingest/error.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
-from botocore.vendored.requests import Response
-
+from requests import Response
 
 class IngestResponseError(Exception):
     """

--- a/snowflake/ingest/utils/network.py
+++ b/snowflake/ingest/utils/network.py
@@ -1,11 +1,5 @@
-# import to use ocsp module in python connector
-# this import will inject ocsp check method into
-# botocore.vendored.requests library
-import snowflake.connector
-
-# use requsts library bundled in botocore
-from botocore.vendored import requests
-from botocore.vendored.requests import Response
+import requests
+from requests import Response
 import time
 from ..error import IngestResponseError
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,8 +45,14 @@ class TestUtil:
 
     @staticmethod
     def read_private_key():
+        """
+        Add your own rsa private key(for testing only) in tests directory
+        Follow instructions here
+        https://docs.snowflake.net/manuals/user-guide/data-load-snowpipe-rest-gs.html#using-key-pair-authentication
+        :return: private key pem encoded
+        """
         tests_dir = os.path.dirname(os.path.realpath(__file__))
-        private_key_filename = os.path.join(tests_dir, "sfctest0_private_key_1.p8")
+        private_key_filename = os.path.join(tests_dir, "rsa_key.p8")
 
         with open(private_key_filename, "rb") as private_key_file:
             private_key = serialization.load_pem_private_key(
@@ -70,9 +76,13 @@ def init_test_schema(request):
     This is automatically called per test session.
     """
     param = get_cnx_param()
+    TEST_DB = param['database']
     with snowflake.connector.connect(**param) as con:
+        con.cursor().execute("CREATE OR REPLACE DATABASE {0}".format(TEST_DB))
+        con.cursor().execute("USE DATABASE {0}".format(TEST_DB))
         con.cursor().execute(
             "CREATE SCHEMA IF NOT EXISTS {0}".format(TEST_SCHEMA))
+        con.cursor().execute("USE SCHEMA {0}".format(TEST_SCHEMA))
 
     def fin():
         param1 = get_cnx_param()


### PR DESCRIPTION
**Why this change:**
Based on few PR and issues, and also from testing, we get 

```You are using the POST() function from 'botocore.vendored.requests'.  This is not a public API in botocore and will be removed in the future. Additionally, this version of requests is out of date.  We recommend you install the requests package, 'import requests' directly, and use the requests.POST() function instead.```

**What this change:**
This is a fix to get away with botocore requests module with standalone requests package. 

**Testing**
Tested pytest inside /tests directory
```python -m pytest test_simple_ingest.py```
