### PR TITLE
Re-add comment explaining unused import

### DIFF
--- a/snowflake/ingest/utils/network.py
+++ b/snowflake/ingest/utils/network.py
@@ -1,4 +1,7 @@
+# This import is not used directly, but it has the effect of monkey-patching
+# the requests library to include an OCSP check.
 import snowflake.connector
+
 import requests
 from requests import Response
 import time


### PR DESCRIPTION
Pull request #35 included the deletion of a comment explaining the
presence of an unused import, which has the effect of a monkey-patch
that this project implicitly relies on.

Without this comment, there is no explanation anywhere in the codebase
for the requirement that this project must include
`snowflake-python-connector`. Since that package has many large
dependencies, readers should have the context to understand why the
inclusion is necessary.