### PR TITLE
[SNOW-160661] Prevent travis to log long traceback when pytest has failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 install:
 - "./scripts/travis_install.sh"
 script:
-- pytest --cov-report xml --cov=snowflake.ingest tests
+- pytest --tb=native --cov-report xml --cov=snowflake.ingest tests
 after_success:
 - pip install codecov
 - codecov -f snowflake-ingest-python-coverage.xml -t 661d6c83-f010-4af1-bf7f-0df1ce3dbc8d


### PR DESCRIPTION
Based on document, default is long which prints lot of other stuff including connection parameters.
https://docs.pytest.org/en/latest/usage.html
Adding a traceback flag with native value

Tested this with and without adding a flag, with flag, prints just the error line. (Or similar to a normal python traceback)

