### PR TITLE
Trim account name if it contains a '.'

### DIFF
--- a/snowflake/ingest/utils/tokentools.py
+++ b/snowflake/ingest/utils/tokentools.py
@@ -13,7 +13,6 @@ from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.hazmat.primitives.serialization import PublicFormat
 from cryptography.hazmat.backends import default_backend
 from snowflake.connector.util_text import parse_account
-
 from ..error import IngestClientError
 from ..errorcode import ERR_INVALID_PRIVATE_KEY
 import base64
@@ -59,7 +58,8 @@ class SecurityManager(object):
             account : %s, user : %s, lifetime : %s, renewal_delay : %s""",
             account, user, lifetime, renewal_delay)
 
-        self.account = parse_account(account.upper())  # Snowflake account names are canonically in all caps
+        # Snowflake account names are canonically in all caps. Also trim account names if contain '.'
+        self.account = parse_account(account.upper())
         self.user = user.upper()  # Snowflake user names are also in all caps by default
         self.qualified_username = self.account + "." + self.user  # Generate the full user name
         self.lifetime = lifetime  # the timedelta until our tokens expire

--- a/snowflake/ingest/utils/tokentools.py
+++ b/snowflake/ingest/utils/tokentools.py
@@ -12,6 +12,8 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.hazmat.primitives.serialization import PublicFormat
 from cryptography.hazmat.backends import default_backend
+from snowflake.connector.util_text import parse_account
+
 from ..error import IngestClientError
 from ..errorcode import ERR_INVALID_PRIVATE_KEY
 import base64
@@ -57,7 +59,7 @@ class SecurityManager(object):
             account : %s, user : %s, lifetime : %s, renewal_delay : %s""",
             account, user, lifetime, renewal_delay)
 
-        self.account = account.upper()  # Snowflake account names are canonically in all caps
+        self.account = parse_account(account.upper())  # Snowflake account names are canonically in all caps
         self.user = user.upper()  # Snowflake user names are also in all caps by default
         self.qualified_username = self.account + "." + self.user  # Generate the full user name
         self.lifetime = lifetime  # the timedelta until our tokens expire
@@ -130,4 +132,5 @@ class SecurityManager(object):
 
         return public_key_fp
 
-
+    def get_account(self) -> Text:
+        return self.account

--- a/tests/test_security_manager.py
+++ b/tests/test_security_manager.py
@@ -1,0 +1,18 @@
+from snowflake.ingest.utils import SecurityManager
+
+
+def test_same_token(test_util):
+    """
+    Tests that accounts are parsed correctly
+    """
+    expected_account = 'TESTACCOUNT'
+
+    actual_account = 'testaccount'
+    user = 'testuser'
+    private_key = ''
+    sec_manager = SecurityManager(actual_account, user, private_key)
+    assert sec_manager.get_account() == expected_account
+
+    actual_account = 'testaccount.something'
+    sec_manager = SecurityManager(actual_account, user, private_key)
+    assert sec_manager.get_account() == expected_account


### PR DESCRIPTION
https://snowflakecomputing.atlassian.net/browse/SNOW-349369

This pr is to fix the case when the account name contains a '.'. Currently, we treat `accountname.something` simply as `accountname` by trimming the string after the dot.

We already supported this in [snowpipe java SDK](https://github.com/snowflakedb/snowflake-ingest-java/pull/78) and [snowflake python connector](https://github.com/snowflakedb/snowflake-connector-python/blob/74c3c6fcf471fd71b392aae752ac4e197ac3171b/src/snowflake/connector/util_text.py#L242).