### PR TITLE
Add compatibility for pyjwt 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ import os
 # We need to know the version to backfill some dependencies
 from sys import version_info, exit
 # Define our list of installation dependencies
-DEPENDS = ["pyjwt<2.0.0", 
-           "snowflake-connector-python", 
-           "furl", 
+DEPENDS = ["pyjwt",
+           "snowflake-connector-python",
+           "furl",
            "cryptography",
-           "requests<2.24.0"]
+           "requests"]
 
 # If we're at version less than 3.4 - fail
 if version_info[0] < 3 or version_info[1] < 4:

--- a/snowflake/ingest/utils/tokentools.py
+++ b/snowflake/ingest/utils/tokentools.py
@@ -105,7 +105,11 @@ class SecurityManager(object):
             self.token = jwt.encode(payload, self.private_key, algorithm=SecurityManager.ALGORITHM)
             logger.info("New Token created")
 
-        return self.token.decode('utf-8')
+        if isinstance(self.token, bytes):
+            # This will be True for PyJWT<2.0.0, so we need to decode to str
+            return self.token.decode("utf-8")
+
+        return self.token
 
     def calculate_public_key_fingerprint(self, private_key: Text) -> Text:
         """


### PR DESCRIPTION
Fixes #63

Update the version of pyjwt and requests used by this library to be compatible
with other modern versions of python packages.

https://github.com/snowflakedb/snowflake-ingest-python/pull/45 made the severely
myopic choice of pinning pyjwt to 1.7.1 rather than updating the code to be
compatible with pyjwt >= 2.0.0. This directly harms all potential consumers of
the package, as they cannot update their code to be hardened to CVEs or consume
other updates of libraries that have incompatible dependencies with
snowflake-ingest's. In a node/npm style language this would be fine, but
Python's dependency resolution mechanics do not allow for installing or relying
on multiple versions of a particular library.

The only significant breaking change introduced by pyjwt 2.0.0 is that the
encode method no longer returns bytes type strings. By checking the return
value, we can know whether to do an extra decode.