### PR TITLE
chore: update copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2013-2016 Snowflake Computing, Inc.
+   Copyright (c) 2012-2023 Snowflake Computing, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/snowflake/ingest/error.py
+++ b/snowflake/ingest/error.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 from requests import Response
 
 class IngestResponseError(Exception):

--- a/snowflake/ingest/errorcode.py
+++ b/snowflake/ingest/errorcode.py
@@ -1,3 +1,3 @@
-#  Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 
 ERR_INVALID_PRIVATE_KEY = 290001

--- a/snowflake/ingest/simple_ingest_manager.py
+++ b/snowflake/ingest/simple_ingest_manager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 """
 simple_ingest_manager - Creates a basic ingest manager that synchronously sends
 requests to the Snowflake Ingest service

--- a/snowflake/ingest/utils/tokentools.py
+++ b/snowflake/ingest/utils/tokentools.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 
 """
 tokentools.py - provides services for automatically creating and renewing

--- a/snowflake/ingest/utils/uris.py
+++ b/snowflake/ingest/utils/uris.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 
 """
 request_builder.py - Builds the URIs and http requests that we send for ingest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 import pytest
 import os
 from cryptography.hazmat.backends import default_backend

--- a/tests/test_unit_tokens.py
+++ b/tests/test_unit_tokens.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 """
 test_tokens.py - This defines a series of tests to ascertain that we are
 capable of renewing JWT tokens


### PR DESCRIPTION
This pull request addresses the critical task of updating the copyright year to reflect the current year, 2023. As part of our commitment to maintaining the project's compliance and adhering to licensing standards, this update is crucial for acknowledging the contributions made to the project during the current year.