### PR TITLE
Bump requests dependency to 2.31.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ DEPENDS = ["pyjwt",
            "snowflake-connector-python>=2.2.7", 
            "furl",
            "cryptography",
-           "requests<=2.28.1"]
+           "requests<=2.31.0"]
 
 # If we're at version less than 3.4 - fail
 if version_info[0] < 3 or version_info[1] < 4:


### PR DESCRIPTION
Bumping requests dependency to 2.31.0 to address [CVE-2023-32681](https://pyup.io/v/58755/97c/).