### PR TITLE
test: Update End2EndTest.yml

### DIFF
--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.7.9', '3.8.7' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'


### PR DESCRIPTION
Fix Python versions used in GitHub workflow, was previously using 3.7.

This should fix the merge issue that's being encountered on these PRs. 