### PR TITLE
SNOW-979362 Upgrade connector for GCP downscoped token

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import os
 from sys import version_info, exit
 # Define our list of installation dependencies
 DEPENDS = ["pyjwt",
-           "snowflake-connector-python>=2.2.7", 
+           "snowflake-connector-python>=3.0.3", 
            "furl",
            "cryptography",
            "requests<=2.31.0"]


### PR DESCRIPTION
SNOW-979362
This PR upgrades the Python connector version used in ingest Python SDK to support GCP downscoped tokens.
https://community.snowflake.com/s/article/faq-2023-client-driver-deprecation-for-GCP-customers