### PR TITLE
SNOW-1632311: Update publish-python.yaml with the correct name

### DIFF
--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -55,14 +55,14 @@ jobs:
             --signature "${dist_base}.sig" \
             --cert "${dist_base}.crt" \
             --cert-oidc-issuer https://token.actions.githubusercontent.com \
-            --cert-identity ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/build_and_sign_demand.yml@${GITHUB_REF}
+            --cert-identity ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/publish-python.yml@${GITHUB_REF}
 
           # Verify using `.sigstore` bundle;
           python -m \
             sigstore verify identity "${dist}" \
             --bundle "${dist_base}.sigstore" \
             --cert-oidc-issuer https://token.actions.githubusercontent.com \
-            --cert-identity ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/build_and_sign_demand.yml@${GITHUB_REF}
+            --cert-identity ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/publish-python.yml@${GITHUB_REF}
           done
     - name: List artifacts after sign
       run: ls ./dist

--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -55,14 +55,14 @@ jobs:
             --signature "${dist_base}.sig" \
             --cert "${dist_base}.crt" \
             --cert-oidc-issuer https://token.actions.githubusercontent.com \
-            --cert-identity ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/publish-python.yml@${GITHUB_REF}
+            --cert-identity ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/publish-python.yaml@${GITHUB_REF}
 
           # Verify using `.sigstore` bundle;
           python -m \
             sigstore verify identity "${dist}" \
             --bundle "${dist_base}.sigstore" \
             --cert-oidc-issuer https://token.actions.githubusercontent.com \
-            --cert-identity ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/publish-python.yml@${GITHUB_REF}
+            --cert-identity ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/publish-python.yaml@${GITHUB_REF}
           done
     - name: List artifacts after sign
       run: ls ./dist


### PR DESCRIPTION
There is an error in the signing step. When validating the signature it uses the github action name used for signing. That name is incorrect and this action will fail. The fix is to use the correct name. 