### PR TITLE
Handle unexpected json structure in error payload

### DIFF
--- a/snowflake/ingest/error.py
+++ b/snowflake/ingest/error.py
@@ -15,12 +15,18 @@ class IngestResponseError(Exception):
                                                                 response.reason)
             return
 
-        self.code = json_body[u'code']
-        self.success = json_body[u'success']
-        self._raw_message = json_body[u'message']
-        self.data = json_body[u'data']
-        self.message = 'Http Error: {}, Vender Code: {}, Message: {}'\
-            .format(self.http_error_code, self.code, self._raw_message)
+        try:
+            self.code = json_body[u'code']
+            self.success = json_body[u'success']
+            self._raw_message = json_body[u'message']
+            self.data = json_body[u'data']
+            self.message = 'Http Error: {}, Vender Code: {}, Message: {}' \
+                .format(self.http_error_code, self.code, self._raw_message)
+        except KeyError:
+            self.message = 'Http Error: {}, Message: {}, Body: {}'.format(self.http_error_code,
+                                                                          response.reason,
+                                                                          json_body)
+
 
         return
 

--- a/snowflake/ingest/error.py
+++ b/snowflake/ingest/error.py
@@ -26,8 +26,6 @@ class IngestResponseError(Exception):
             self.message = 'Http Error: {}, Message: {}, Body: {}'.format(self.http_error_code,
                                                                           response.reason,
                                                                           json_body)
-
-
         return
 
     def __str__(self):


### PR DESCRIPTION
Addresses the issue where handling any API error response that does not conform to expected JSON response raises KeyError rather providing information about the HTTP error.

Works by catching any KeyErrors and instead providing a generically informative exception message based on the one reported if there is no JSON payload.

closes: #92