### PR TITLE
SNOW-2442924 bump requests to 2.32.4 to fix CVE-2024-47081

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ DEPENDS = ["pyjwt",
            "snowflake-connector-python>=3.12.0", 
            "furl",
            "cryptography",
-           "requests<=2.32.3"]
+           "requests<=2.32.4"]
 
 # If we're at version less than 3.4 - fail
 if version_info[0] < 3 or version_info[1] < 4:


### PR DESCRIPTION
### Description
https://nvd.nist.gov/vuln/detail/CVE-2024-47081 is fixed with `requests>=2.32.4` . Ideally, we should bump to latest 2.32.5, but it dropped Python 3.8 support (as it should, it's EOL..) - but we still only require Python 3.4 as a minimum runtime here. 

So to avoid breaking people who still possibly use this library on Python 3.8 (allowed by this library), not bumping to latest but the latest which has the CVE fixed. We can figure out Python dependency requirements separately. 

