### PR TITLE
Bump requests to 2.32.4 to fix CVE-2024-47081

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ DEPENDS = ["pyjwt",
            "snowflake-connector-python>=3.0.3", 
            "furl",
            "cryptography",
-           "requests<=2.32.3"]
+           "requests<=2.32.4"]
 
 # If we're at version less than 3.4 - fail
 if version_info[0] < 3 or version_info[1] < 4:


### PR DESCRIPTION
Bump requests to 2.32.4 to fix CVE-2024-47081.
Replacing https://github.com/snowflakedb/snowflake-ingest-python/pull/105