### PR TITLE
SNOW-3653053: bump requests upper bound to 2.33.0

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -7,6 +7,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-inges
 
 Release Notes
 -------------------------------------------------------------------------------
+- v1.0.13 (June 17, 2026)
+
+      - Update dependency package to newer version (requests)
+
 - v1.0.12 (Oct 22, 2025)
 
       - Update dependency package to newer version (requests)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ DEPENDS = ["pyjwt",
            "snowflake-connector-python>=3.12.0", 
            "furl",
            "cryptography",
-           "requests<=2.32.4"]
+           "requests<=2.33.0"]
 
 # If we're at version less than 3.4 - fail
 if version_info[0] < 3 or version_info[1] < 4:

--- a/snowflake/ingest/version.py
+++ b/snowflake/ingest/version.py
@@ -1,3 +1,3 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 # Update this for the versions
-__version__ = '1.0.12'
+__version__ = '1.0.13'


### PR DESCRIPTION
Bump requests upper bound to 2.33.0 to unblock CVE-2026-25645 remediation